### PR TITLE
Add operations in seconds for block acccess

### DIFF
--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -688,7 +688,7 @@ if("$opt{'check_type'}" eq "TEMP") {
 	my $check=$fcpops_per_seconds;
 
 	($msg,$stat) = _clac_absolute_err_stat($check,$opt{'check_type'},$opt{'warn'},$opt{'crit'});
-        $msg = "$msg ops/s (fcp read=$fcpread_per_seconds B/s, fcp write=$fcpwrite_per_seconds B/s, disk read=$diskread_per_seconds B/s, disk write=$diskwrite_per_seconds B/s))";
+        $msg = "$msg ops/s (fcp read=$fcpread_per_seconds B/s, fcp write=$fcpwrite_per_seconds B/s, disk read=$diskread_per_seconds B/s, disk write=$diskwrite_per_seconds B/s)";
 	$perf = "fcpops=$check fcpread=$fcpread_per_seconds fcpwrite=$fcpwrite_per_seconds diskread=$diskread_per_seconds diskwrite=$diskwrite_per_seconds";
 ### NVRAM ###
 } elsif("$opt{'check_type'}" eq "NVRAM") {

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -259,8 +259,8 @@ my %EcnlStatusIndex = (
 
 
 sub _create_session(@) {
-	my ($server, $comm, $version) = @_;
-	my ($sess, $err) = Net::SNMP->session( -hostname => $server, -version => $version, -community => $comm);
+	my ($server, $comm, $version, $timeout) = @_;
+	my ($sess, $err) = Net::SNMP->session( -hostname => $server, -version => $version, -community => $comm, -timeout => $timeout);
 	if (!defined($sess)) {
 		print "Can't create SNMP session to $server\n";
 		exit(1);
@@ -279,7 +279,8 @@ $err
        -H <IP or Hostname>    Ip/Dns Name of the Filer
        -C <community name>    SNMP Community Name for read
        -V <1|2c>              SNMP version (default 1)
-       -T <Check type>        Type of check, see bellow
+       -T <check type>        Type of check, see bellow
+       -t <seconds>           Timeout to SNMP session in seconds (default 5)
 
        -w <number>            Warning Value (default 500)
        -c <number>            Critical Value (default 500)
@@ -407,6 +408,7 @@ sub _clac_minutes_err_stat(@) {
 $opt{'crit'} = 500;
 $opt{'warn'} = 500;
 $opt{'version'} = 1;
+$opt{'timeout'} = 5;
 my $result = GetOptions(\%opt,
 						'filer|H=s',
 						'community|C=s',
@@ -417,6 +419,7 @@ my $result = GetOptions(\%opt,
 						'vol|v=s',
 						'exclude|e=s',
                                                 'inform|I',
+                                                'timeout|t=i',
 						);
 
 FSyntaxError("Missing -H")  unless defined $opt{'filer'};
@@ -452,7 +455,7 @@ if (!defined($counterFilePath)) {
 alarm($TIMEOUT);
 
 # Establish SNMP Session
-our $snmp_session = _create_session($opt{'filer'},$opt{'community'},$opt{'version'});
+our $snmp_session = _create_session($opt{'filer'},$opt{'community'},$opt{'version'},$opt{'timeout'});
 
 # setup counterFile now that we have host IP and check type
 $counterFile = $counterFilePath."/".$opt{'filer'}.".check-netapp-ng.$opt{'check_type'}.nagioscache";

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -277,9 +277,9 @@ sub _create_session(@) {
 sub FSyntaxError($) {
 	my $err = shift;
 	print <<EOU;
-This is $script_name in version $script_version.
-
 $err
+
+This is $script_name in version $script_version.
 
   Syntax:
     -H <IP or Hostname>     Ip/Dns Name of the Filer

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -287,10 +287,10 @@ $err
     -V <1|2c>               SNMP version (default 1), some checks run only 2c
     -T <check type>         Type of check, see bellow
     -t <seconds>            Timeout to SNMP session in seconds (default 5)
-
     -w <number>             Warning Value (default 500)
     -c <number>             Critical Value (default 500)
-    -v <vol_path|aggr_name> Volume Name in format /vol/volname/ or aggregate name
+    -v <vol_path|aggr_name> Volume Name in format /vol/volname/ 
+                            or aggregate name (not available in 7.x ONTAP)
     -e <vol1[,vol2[,...]]>  Exclude volumes from snap check (SNAPSHOT)
     -I                      Inform only, return OK every time (ignore -w and -c values)
     -h                      This help
@@ -884,16 +884,15 @@ if("$opt{'check_type'}" eq "TEMP") {
                                 $perf_temp = "$perf_temp, temp_$shelf{'ShelfNumber'}=$1";
                         }
 		    }
-		    else
-		     { print "$subkey->"; print "None "; }
+		    #else { print "$subkey->"; print "None "; }
 			
 			if ("$opt{'check_type'}" eq "SHELF") {
 			if(($shelf{$subkey} ne "") and ($shelf{$subkey} ne "noSuchInstance")) { push(@shelf_err,"$addr $subkey,") }
 			}
 		}
 
-		{ print "\n"; }
-		##if ("$opt{'check_type'}" eq "SHELFINFO") { print "\n"; }
+		#{ print "\n"; }
+		#if ("$opt{'check_type'}" eq "SHELF") { print "\n"; }
 
 		if($#shelf_err != -1) {
 			push(@errs,@shelf_err)

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -724,7 +724,7 @@ if("$opt{'check_type'}" eq "TEMP") {
 
 			($msg,$stat) = _clac_err_stat($used_prec,$opt{'check_type'},$opt{'warn'},$opt{'crit'});
 
-			$perf = "$$r_vol_tbl{$key}=$used\k";
+			$perf = "$$r_vol_tbl{$key}=$used\KB";
 		}
 	}
         if ($msg =~ /^$/) {

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -712,8 +712,10 @@ if("$opt{'check_type'}" eq "TEMP") {
 			my @tmp_arr = split(/\./, $key);
 			my $oid = pop(@tmp_arr);
                         my $used = "";
+                        my $capacity = "";
 			if ($opt{'version'} eq '2c') {
                                 $used = _get_oid_value($snmp_session,"$snmp_netapp_volume_id_table_df64_used.$oid");
+                                $capacity = _get_oid_value($snmp_session,"$snmp_netapp_volume_id_table_df64_total.$oid");
                         }
                         else {
                                 my $used_high = _get_oid_value($snmp_session,"$snmp_netapp_volume_id_table_df_used_high.$oid");
@@ -724,7 +726,10 @@ if("$opt{'check_type'}" eq "TEMP") {
 
 			($msg,$stat) = _clac_err_stat($used_prec,$opt{'check_type'},$opt{'warn'},$opt{'crit'});
 
-			$perf = "$$r_vol_tbl{$key}=$used\KB";
+                        # https://nagios-plugins.org/doc/guidelines.html
+                        # 'label'=value[UOM];[warn];[crit];[min];[max]
+			$perf =   "$$r_vol_tbl{$key}=$used\KB;" .floor($capacity*$opt{'warn'}/100) .";" .floor($capacity*$opt{'crit'}/100) .";;$capacity";
+                        $perf .= " $$r_vol_tbl{$key}:perc=$used_prec\%;" .floor($opt{'warn'}) .";" .floor($opt{'crit'}) .";;100"; 
 		}
 	}
         if ($msg =~ /^$/) {

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -669,7 +669,6 @@ if("$opt{'check_type'}" eq "TEMP") {
                                 my $used_high = _get_oid_value($snmp_session,"$snmp_netapp_volume_id_table_df_used_high.$oid");
                                 my $used_low  = _get_oid_value($snmp_session,"$snmp_netapp_volume_id_table_df_used_low.$oid");
                                 $used = _ulong64($used_high, $used_low);
-                                print "$used_high | $used_low | $used\n";
                         }
 			my $used_prec = _get_oid_value($snmp_session,"$snmp_netapp_volume_id_table_df_used_prec.$oid");
 

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -731,7 +731,7 @@ if("$opt{'check_type'}" eq "TEMP") {
                 $stat = $ERRORS{'WARNING'};
                 $msg = "WARN: Unknown volume path or aggregate name '$opt{'vol'}'. Available values:";
                 foreach my $key (sort keys %$r_vol_tbl) {
-                        next if $$r_vol_tbl{$key} =~ m#.*/\.snapshot$#;
+                        next if ( !( ($$r_vol_tbl{$key} =~ m#^/vol/.*/$#) or ($$r_vol_tbl{$key} =~ m#^[^/]*$#) ) );
                         $msg .= " $$r_vol_tbl{$key}"
                 }
         }                

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -878,8 +878,7 @@ if("$opt{'check_type'}" eq "TEMP") {
 
 
 		foreach my $subkey ( keys %shelf) {
-		    if ( $shelf{$subkey} ne "" ) {
-		    	print "$subkey->$shelf{$subkey} ";
+		    if ( ($shelf{$subkey} ne "") and ($shelf{$subkey} ne "noSuchInstance") ) {
                         if ( "$subkey" eq "CurrentTemp" ) {
                                 $shelf{$subkey} =~ m/^([0-9]+)C.*$/;
                                 $perf_temp = "$perf_temp, temp_$shelf{'ShelfNumber'}=$1";
@@ -889,7 +888,7 @@ if("$opt{'check_type'}" eq "TEMP") {
 		     { print "$subkey->"; print "None "; }
 			
 			if ("$opt{'check_type'}" eq "SHELF") {
-			if($shelf{$subkey}) { push(@shelf_err,"$addr $subkey,") }
+			if(($shelf{$subkey} ne "") and ($shelf{$subkey} ne "noSuchInstance")) { push(@shelf_err,"$addr $subkey,") }
 			}
 		}
 


### PR DESCRIPTION
Changes:
* add FCPOPS to getting operations over FibreChannel
* add ISCSIOPS to getting operations over FibreChannel
* add -t option ... timeout for Net::SNMP session, fix for https://exchange.nagios.org/directory/Plugins/Hardware/Storage-Systems/SAN-and-NAS/NetApp/Check-Netapp-NG/details#rev-3387
* add -V option ... change version of SNMP connection, this is necessary for reading 64bit values, fix https://exchange.nagios.org/directory/Plugins/Hardware/Storage-Systems/SAN-and-NAS/NetApp/Check-Netapp-NG/details#rev-3036
* add -I option ... every time check return OK, this is good for creating graph
* change version of script from 1.1 to 1.2
* redesing help message and append examples
* nagioscache files used only if needed
* each test using own nagioscache file, gets more precisely performance data

