### PR TITLE
Added warning ang critical threshold output to "CPULOAD" perfdata...

### DIFF
--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -648,7 +648,7 @@ if("$opt{'check_type'}" eq "TEMP") {
 } elsif("$opt{'check_type'}" eq "CPULOAD") {
 	my $check = _get_oid_value($snmp_session,$snmpcpuBusyTimePerCent);
 	($msg,$stat) = _clac_err_stat($check,$opt{'check_type'},$opt{'warn'},$opt{'crit'});
-	$perf = "cpuload=$check\%";
+	$perf = "cpuload=$check\%;$opt{'warn'};$opt{'crit'};;";
 ### NFSOPS ###
 } elsif("$opt{'check_type'}" eq "NFSOPS") {
 	my $nfsops_per_seconds=floor ( ($total_nfs_ops-$fileNfsOps)/$elapsedtime );


### PR DESCRIPTION
...for better graphing with pnp4nagios.

As the nagios plugin development guideline (https://nagios-plugins.org/doc/guidelines.html) descripbes:
performance data shoud be look like:
'label'=value[UOM];[warn];[crit];[min];[max]
