### PR TITLE
dont require ending slash

### DIFF
--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -19,7 +19,7 @@
 ## 20160211 : Added FSSTATUS/SNAPSHOTAGE
 ##
 ## the following parameters has
-## been tested against a 
+## been tested against a
 ## FAS2220
 ## FAS2240
 ## FAS3220
@@ -348,7 +348,7 @@ This is $script_name in version $script_version.
     -t <seconds>            Timeout to SNMP session in seconds (default 5)
     -w <number>             Warning Value (default 500)
     -c <number>             Critical Value (default 500)
-    -v <vol_path|aggr_name> Volume Name in format /vol/volname/
+    -v <vol_path|aggr_name> Volume Name in format /vol/volname
                             or aggregate name (not available in 7.x ONTAP)
                             For available values use any word, such as \'-v whatever\'
     -e <vol1[,vol2[,...]]>  Exclude volumes from snap check (SNAPSHOT/SNAPSHOTAGE)
@@ -510,8 +510,8 @@ FSyntaxError("Missing -H")  unless defined $opt{'filer'};
 FSyntaxError("Missing -C")  unless defined $opt{'community'};
 FSyntaxError("Missing -T")  unless defined $opt{'check_type'};
 if($opt{'vol'}) {
-        if ( !( ($opt{'vol'} =~ m#^/vol/.*/$#) or ($opt{'vol'} =~ m#^[^/]*$#) ) )  {
-                FSyntaxError("$opt{'vol'} format is '/vol/volname/' or 'aggregate_name'! For listing available names use any text such as '-v whatever'.");
+        if ( !( ($opt{'vol'} =~ m#^/vol/.*$#) or ($opt{'vol'} =~ m#^[^/]*$#) ) )  {
+                FSyntaxError("$opt{'vol'} format is '/vol/volname' or 'aggregate_name'! For listing available names use any text such as '-v whatever'.");
         }
 }
 if($opt{'crit'} and $opt{'warn'}) {

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -773,7 +773,7 @@ if("$opt{'check_type'}" eq "TEMP") {
                 $stat = $ERRORS{'WARNING'};
                 $msg = "WARN: Unknown volume path or aggregate name '$opt{'vol'}'. Available values:";
                 foreach my $key (sort keys %$r_vol_tbl) {
-                        next if ( !( ($$r_vol_tbl{$key} =~ m#^/vol/.*/$#) or ($$r_vol_tbl{$key} =~ m#^[^/]*$#) ) );
+                        next if ( !( ($$r_vol_tbl{$key} =~ m#^/vol/.*$#) or ($$r_vol_tbl{$key} =~ m#^[^/]*$#) ) );
                         $msg .= " $$r_vol_tbl{$key}"
                 }
                 }

--- a/nagios/check-netapp-ng.pl
+++ b/nagios/check-netapp-ng.pl
@@ -38,6 +38,8 @@ use strict;
 use POSIX;
 use lib "/usr/lib/nagios/libexec";
 use lib "/usr/lib/nagios/plugins";
+use lib "/usr/lib64/nagios/libexec";
+use lib "/usr/lib64/nagios/plugins";
 use utils qw($TIMEOUT %ERRORS);
 use Net::SNMP;
 use File::Basename;


### PR DESCRIPTION
I'm not sure if it's the netapp version but on some our volumes do not have a ending slash. So we were unable to check them.
```
18:15 $ ./check-netapp-ng.pl -H netapp1 -C nocstats -T DISKUSED -w 85 -c 95 -v wtf                                                                                                      
WARN: Unknown volume path or aggregate name 'wtf'. Available values: aggr0 /vol/tuk_vmdatastore_01/.snapshot /vol/INFRABACKUP/ /vol/INFRABACKUP/.snapshot /vol/rdu_mysqlbackup/ /vol/rdu_mysqlbackup/.. /vol/logs/ /vol/logs/.. /vol/rdu_infrabackup/ /vol/rdu_infrabackup/.snapshot /vol/vol0/ /vol/vol0/.snapshot /vol/raid/ /vol/raid/.snapshot /vol/MYSQLBACKUP/ /vol/MYSQLBACKUP/.. /vol/tuk_vmdatastore_01/


18:12 $ ./check-netapp-ng.pl -H netapp2 -C nocstats -T DISKUSED -w 85 -c 95 -v wtf
WARN: Unknown volume path or aggregate name 'wtf'. Available values: aggr0_tukp_sto2_c1_n2_root /vol/vol0 /vol/vol0/.snapshot aggr1_tukp_sto2_c1_n1_3tb /vol/rootvol /vol/rootvol/.snapshot /vol/backups /vol/backups/.snapshot aggr1_tukp_sto2_c1_n1_4tb /vol/backups2 /vol/backups2/.snapshot aggr0_tukp_sto2_c1_n1_root /vol/vol0 /vol/vol0/.snapshot
```